### PR TITLE
Update internships.csv

### DIFF
--- a/internships.csv
+++ b/internships.csv
@@ -1,7 +1,7 @@
 Name,Position,Location,Class Year,International,Notes,URL
 Akuna,Many types,"Chicago, IL; Sydney, Australia; Shanghai; Boston, MA","Junior, Senior",,,https://akunacapital.com/careers#careers
 Amazon,SDE,"Seattle, WA; Austin, TX; Bellevue, WA; Boston, MA; Denver, CO; Detriot, MI; Herndon, VA; Irvine, CA; NY, NY; Madison, WI; Minneapolis, MN; Phoenix, AZ;Portland, OR; San Diego, CA; Vancouver, Canada; Toronto, Canada; Winnipeg Canada",,,,https://www.amazon.jobs/en/teams/internships-for-students
-American Express,SDE ,"Phoenix, AZ; Ft. Lauderdale, FL; NY, NY","Sophomores, Junior, Senior",,,https://jobs.americanexpress.com/jobs/19003378?
+American Express,SDE ,"Phoenix, AZ; Ft. Lauderdale, FL; NY, NY","Sophomores, Junior, Senior","No sponsorship",,https://jobs.americanexpress.com/jobs/19003378?
 Apple,"SWE, Hardware, UI/UX, Sales, ML","Santa Clara Valley (Cupertino), CA (Mainly)",,,,https://jobs.apple.com/en-us/search?location=united-states-USA&team=Internships-STDNT-INTRN
 Atlassian,SDE,"Mountian View, CA","Junior, Senior",,,https://jobs.lever.co/atlassian/9484630b-4039-415e-af9a-c1e2c34e5a8b
 Belvedere Trading,SDE,"Chicago, IL","Junior, Senior",No sponsorship,,http://belvederetrading.applicantstack.com/x/detail/a2sa4x08859m


### PR DESCRIPTION
American express doesn't sponsor visas.

https://jobs.americanexpress.com/jobs/19003378?lang=en-us&previousLocale=en-US

"Employment eligibility to work with American Express in the U.S. is required as the company  will not pursue visa sponsorship for these positions."